### PR TITLE
Inline Terraform plan step in apply workflow

### DIFF
--- a/.github/workflows/terraform-apply-policies.yml
+++ b/.github/workflows/terraform-apply-policies.yml
@@ -15,7 +15,6 @@ permissions:
 jobs:
   terraform-apply:
     runs-on: ubuntu-latest
-    needs: call-terraform-plan
     env:
       ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}


### PR DESCRIPTION
Removes the separate 'call-terraform-plan' job and adds the Terraform plan step directly to the apply workflow. This simplifies the workflow by reducing job dependencies and improves maintainability.