### PR TITLE
Add role assignment module and outputs for Function App

### DIFF
--- a/.github/workflows/terraform-apply-resources.yml
+++ b/.github/workflows/terraform-apply-resources.yml
@@ -62,6 +62,7 @@ jobs:
         run: |
           terraform plan \
             -var-file="envs/${{ env.TARGET_ENVIRONMENT }}/terraform.tfvars" \
+            -var="azure_deployment_principal_id=${{ secrets.AZURE_CLIENT_ID }}" \
             -var="function_app_settings_additional=${{ env.TARGET_ENVIRONMENT }}"
 
       - name: 'Run Terraform Apply'
@@ -69,4 +70,5 @@ jobs:
           terraform apply \
             -auto-approve \
             -var-file="envs/${{ env.TARGET_ENVIRONMENT }}/terraform.tfvars" \
+            -var="azure_deployment_principal_id=${{ secrets.AZURE_CLIENT_ID }}" \
             -var="function_app_settings_additional=${{ env.TARGET_ENVIRONMENT }}"

--- a/.github/workflows/terraform-plan-resources.yml
+++ b/.github/workflows/terraform-plan-resources.yml
@@ -62,4 +62,5 @@ jobs:
         run: |
           terraform plan \
             -var-file="envs/${{ env.TARGET_ENVIRONMENT }}/terraform.tfvars" \
+            -var="azure_deployment_principal_id=${{ secrets.AZURE_CLIENT_ID }}" \
             -var="function_app_settings_additional=${{ env.TARGET_ENVIRONMENT }}"

--- a/modules/function_app_flex_consumption/outputs.tf
+++ b/modules/function_app_flex_consumption/outputs.tf
@@ -1,0 +1,9 @@
+output "id" {
+  value       = azurerm_function_app_flex_consumption.this.id
+  description = "The ID of the Function App Flex Consumption"
+}
+
+output "system_assigned_managed_identity_principal_id" {
+  value       = azurerm_function_app_flex_consumption.this.identity[0].principal_id
+  description = "The Object ID of the System Assigned Managed Identity"
+}

--- a/modules/role_assignment/main.tf
+++ b/modules/role_assignment/main.tf
@@ -1,0 +1,16 @@
+# https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment
+resource "azurerm_role_assignment" "this" {
+  # Required
+  scope                                  = var.scope
+  # Optional
+  # name                                   = var.name
+  # role_definition_id                     = var.role_definition_id
+  role_definition_name                   = var.role_definition_name
+  principal_id                           = var.principal_id
+  principal_type                         = var.principal_type
+  # condition                              = var.condition
+  # condition_version                      = var.condition_version
+  # delegated_managed_identity_resource_id = var.delegated_managed_identity_resource_id
+  # description                            = var.description
+  # skip_service_principal_aad_check       = var.skip_service_principal_aad_check
+}

--- a/modules/role_assignment/variables.tf
+++ b/modules/role_assignment/variables.tf
@@ -1,0 +1,19 @@
+variable "scope" {
+  description = "The scope at which the role assignment applies"
+  type        = string
+}
+
+variable "principal_id" {
+  description = "The ID of the principal to assign the role to"
+  type        = string
+}
+
+variable "role_definition_name" {
+  description = "The name of the role definition to assign"
+  type        = string
+}
+
+variable "principal_type" {
+  description = "The type of the principal (User, Group, ServicePrincipal)"
+  type        = string
+}

--- a/subscriptions/Pay-As-You-Go/main.tf
+++ b/subscriptions/Pay-As-You-Go/main.tf
@@ -178,3 +178,36 @@ module "function_app_flex_consumption_sample" {
     "hidden-link: /app-insights-resource-id" = module.application_insights_function.id
   }
 }
+
+output "function_app_flex_consumption_id" {
+  value = module.function_app_flex_consumption_sample.id
+}
+
+output "function_app_flex_consumption_system_assigned_managed_identity_principal_id" {
+  value = module.function_app_flex_consumption_sample.system_assigned_managed_identity_principal_id
+}
+
+### Sample: Azure RBAC - Managed identities for Function App
+module "role_assignment_storage_blob_data_contributor_function_app" {
+  source                = "../../modules/role_assignment"
+  scope                 = module.storage_container_function_app_packages.storage_container_id
+  role_definition_name  = "Storage Blob Data Contributor"
+  principal_id          = module.function_app_flex_consumption_sample.system_assigned_managed_identity_principal_id
+  principal_type        = "ServicePrincipal"
+}
+
+module "role_assignment_monitoring_metrics_publisher_function_app" {
+  source                = "../../modules/role_assignment"
+  scope                 = module.application_insights_function.id
+  role_definition_name  = "Monitoring Metrics Publisher"
+  principal_id          = module.function_app_flex_consumption_sample.system_assigned_managed_identity_principal_id
+  principal_type        = "ServicePrincipal"
+}
+
+module "role_assignment_website_contributor_function_app" {
+  source                = "../../modules/role_assignment"
+  scope                 = module.function_app_flex_consumption_sample.id
+  role_definition_name  = "Website Contributor"
+  principal_id          = var.azure_deployment_principal_id
+  principal_type        = "ServicePrincipal"
+}

--- a/subscriptions/Pay-As-You-Go/variables.tf
+++ b/subscriptions/Pay-As-You-Go/variables.tf
@@ -149,6 +149,12 @@ variable "function_app_setting_names" {
 }
 
 # From Actions
+variable "azure_deployment_principal_id" {
+  description = "The principal ID of the Azure deployment"
+  type        = string
+  default     = ""
+}
+
 variable "function_app_settings_additional" {
   description = "Additional application settings for the Function App"
   type        = string


### PR DESCRIPTION
Introduces a reusable role_assignment Terraform module and integrates it with the Function App Flex Consumption sample. Adds outputs for Function App ID and managed identity principal ID, updates workflows to pass azure_deployment_principal_id, and defines the corresponding variable in Pay-As-You-Go subscription configuration.